### PR TITLE
Allow for customArgs

### DIFF
--- a/lib/nearest-neighbor.js
+++ b/lib/nearest-neighbor.js
@@ -3,7 +3,7 @@
   var calculateSum, exactSimilarity, intersect, ipArraySimilarity, ipSimilarity, numberSimilarity, recordSimilarity, tokenize, wordArraySimilarity, wordSimilarity;
 
   recordSimilarity = function(a, b, fields) {
-    var i, measure, name, similarity, sum, unmatchedFields;
+    var i, measure, name, similarity, sum, unmatchedFields, customArgs;
 
     sum = 0;
     i = 0;
@@ -11,16 +11,15 @@
     while (i < fields.length) {
       name = fields[i].name;
       measure = fields[i].measure;
-      if ('' + measure === '' + exports.comparisonMethods.number) {
-        if (typeof fields[i].max !== 'undefined' && fields[i].max !== null) {
-          similarity = measure(a[name], b[name], fields[i].max);
-        } else {
-          console.warn("max number missing, falling back to max: 9007199254740992");
-          similarity = measure(a[name], b[name], 9007199254740992);
-        }
+      
+      if(fields[i].args){
+        customArgs = fields[i].args;
       } else {
-        similarity = measure(a[name], b[name]);
+        customArgs = {};
       }
+
+      similarity = measure(a[name], b[name], customArgs);
+      
       if (similarity < 1.0) {
         unmatchedFields[name] = similarity;
       }
@@ -99,8 +98,15 @@
     return 0;
   };
 
-  numberSimilarity = function(a, b, max) {
+  numberSimilarity = function(a, b, args) {
     var diff, diff1, diff2, distance;
+
+    if(!args.max){
+        console.warn("max number missing, falling back to max: 9007199254740992");
+        max = 9007199254740992;
+    } else {
+        max = args.max;
+    }
 
     diff1 = max - a;
     diff2 = max - b;


### PR DESCRIPTION
Add custom args so that custom comparison methods can provide more args such as max etc.

Fields would change to.

``` js
var fields = [
    { name: "x", measure: nn.comparisonMethods.custom, args: {max: 10} },
    { name: "y", measure: nn.comparisonMethods.custom, args: {max: 10} }
];
```

custom comparison mathods would be

``` js
nn.comparisonMethods.custom = function(a, b, args) {
    // Test for args and enforce defaults...

    // compare something...
    var value = ...
    return value; // between 0 and 1
};
```
